### PR TITLE
[Bug fix] context data keys can have values and sub-values ( e.g. a.b…

### DIFF
--- a/test/src/Analytics/ContextDataUtil.test.js
+++ b/test/src/Analytics/ContextDataUtil.test.js
@@ -73,6 +73,14 @@ describe('test Analytics/ContextDataUtil.js', () => {
             data.set('key_1', 'val_1');
             assert.equal(serializeAnalyticsRequest(data, null), "ndh=1&c.&a.&key1=val1&key2=val2&b.&key1=val1&key2=val2&.b&.a&key_1=val_1&.c");
         });
+        it('should pass, when input data contains keys like <a.b.c> & <a.b>', () => {
+            let data = new Map();
+            data.set('a.key1', 'val1');
+            data.set('a.key2', 'val2');
+            data.set('a.b', 'val1');
+            data.set('a.b.c', 'val2');
+            assert.equal(serializeAnalyticsRequest(data, null), "ndh=1&c.&a.&key1=val1&key2=val2&b=val1&b.&c=val2&.b&.a&.c");
+        });
         it('should pass, when input data contains special keys like <&&skey1>', () => {
             let data = new Map();
             data.set('a.key1', 'val1');
@@ -115,32 +123,32 @@ describe('test Analytics/ContextDataUtil.js', () => {
         it('should return a right object, when input with valid string', () => {
             const obj = {};
             _applyPropertyToObj(['a', 'b', 'c'], obj, 'xxx');
-            assert.deepEqual(obj, { a: { b: { c: 'xxx' } } });
+            assert.deepEqual(obj, { a: { b: { c: { '#node_value': 'xxx' } } } });
         });
     });
     describe('# _stringifyObj()', () => {
         it('should reutrn string, when input obj and key are valid', () => {
             const obj = {
                 a: {
-                    b: 'abbb',
-                    c: 'accc'
+                    b: { '#node_value': 'abbb' },
+                    c: { '#node_value': 'accc' }
                 },
-                b: 'bbb',
-                c: 'ccc'
+                b: { '#node_value': 'bbb' },
+                c: { '#node_value': 'ccc' }
             };
             assert.equal(_stringifyObj(obj, 'c'), '&c.&a.&b=abbb&c=accc&.a&b=bbb&c=ccc&.c');
         });
         it('should reutrn string, when input obj and key are valid ..', () => {
             const obj = {
                 a: {
-                    b: 'abbb',
-                    c: 'accc'
+                    b: { '#node_value': 'abbb' },
+                    c: { '#node_value': 'accc' }
                 },
-                b: 'bbb',
-                c: 'ccc',
+                b: { '#node_value': 'bbb' },
+                c: { '#node_value': 'ccc' },
                 d: {
-                    x: 'dxxx',
-                    y: 'dyyy'
+                    x: { '#node_value': 'dxxx' },
+                    y: { '#node_value': 'dyyy' }
                 }
             };
             assert.equal(_stringifyObj(obj, 'c'), '&c.&a.&b=abbb&c=accc&.a&b=bbb&c=ccc&d.&x=dxxx&y=dyyy&.d&.c');
@@ -148,16 +156,16 @@ describe('test Analytics/ContextDataUtil.js', () => {
         it('should reutrn string, when input obj and key are valid (depth=2)', () => {
             const obj = {
                 a: {
-                    b: 'abbb',
-                    c: 'accc'
+                    b: { '#node_value': 'abbb' },
+                    c: { '#node_value': 'accc' }
                 },
-                b: 'bbb',
-                c: 'ccc',
+                b: { '#node_value': 'bbb' },
+                c: { '#node_value': 'ccc' },
                 d: {
-                    x: 'dxxx',
+                    x: { '#node_value': 'dxxx' },
                     y: {
-                        a: 'dyaaa',
-                        b: 'dybbb'
+                        a: { '#node_value': 'dyaaa' },
+                        b: { '#node_value': 'dybbb' }
                     }
                 }
             };
@@ -173,22 +181,38 @@ describe('test Analytics/ContextDataUtil.js', () => {
                 'b': 'bbb',
                 'c': 'ccc',
                 'd.x': 'dxxx',
+                'd.y': 'dddd',
                 'd.y.a': 'dyaaa',
                 'd.y.b': 'dybbb'
             }));
 
             assert.deepEqual(_convertDataMapToObj(map), {
                 a: {
-                    b: 'abbb',
-                    c: 'accc'
+                    b: {
+                        '#node_value': 'abbb'
+                    },
+                    c: {
+                        '#node_value': 'accc'
+                    }
                 },
-                b: 'bbb',
-                c: 'ccc',
+                b: {
+                    '#node_value': 'bbb'
+                },
+                c: {
+                    '#node_value': 'ccc'
+                },
                 d: {
-                    x: 'dxxx',
+                    x: {
+                        '#node_value': 'dxxx'
+                    },
                     y: {
-                        a: 'dyaaa',
-                        b: 'dybbb'
+                        "#node_value": "dddd",
+                        a: {
+                            '#node_value': 'dyaaa'
+                        },
+                        b: {
+                            '#node_value': 'dybbb'
+                        }
                     }
                 }
             });


### PR DESCRIPTION
…='xx', a.b.c='xxx')

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
